### PR TITLE
Allow specifying version in aux data calculation

### DIFF
--- a/aux_data.go
+++ b/aux_data.go
@@ -40,7 +40,7 @@ func auxDepositHasher() Sha256 {
 	return h
 }
 
-// ComputeAuxData Compute the AuxData.
+// computeAuxData Compute the AuxData.
 //
 // This is defined as
 //
@@ -51,7 +51,7 @@ func auxDepositHasher() Sha256 {
 // - 'Version' is a byte useful if different deposit versions should refer to different deposit addresses
 // - 'nonce' allows to generate different deposit addresses given same inputs
 // - 'ReferrerId' is an arbitrary 16 bytes array for application usage
-func ComputeAuxData(nonce uint32, referrerId []byte, version DepositAuxVersion) ([]byte, error) {
+func computeAuxData(nonce uint32, referrerId []byte, version DepositAuxVersion) ([]byte, error) {
 	if len(referrerId) > MaxReferralIdSize {
 		return nil, errors.Errorf("wrong size for referrerId (got %v, want not greater than %v)", len(referrerId), MaxReferralIdSize)
 	}
@@ -79,10 +79,10 @@ func ComputeAuxData(nonce uint32, referrerId []byte, version DepositAuxVersion) 
 
 // ComputeAuxDataV0 Compute the AuxData with version 0
 func ComputeAuxDataV0(nonce uint32, referrerId []byte) ([]byte, error) {
-	return ComputeAuxData(nonce, referrerId, DepositAuxV0)
+	return computeAuxData(nonce, referrerId, DepositAuxV0)
 }
 
 // ComputeAuxDataV1 Compute the AuxData with version 1
 func ComputeAuxDataV1(nonce uint32, referrerId []byte) ([]byte, error) {
-	return ComputeAuxData(nonce, referrerId, DepositAuxV1)
+	return computeAuxData(nonce, referrerId, DepositAuxV1)
 }

--- a/aux_data.go
+++ b/aux_data.go
@@ -81,3 +81,8 @@ func ComputeAuxData(nonce uint32, referrerId []byte, version DepositAuxVersion) 
 func ComputeAuxDataV0(nonce uint32, referrerId []byte) ([]byte, error) {
 	return ComputeAuxData(nonce, referrerId, DepositAuxV0)
 }
+
+// ComputeAuxDataV1 Compute the AuxData with version 1
+func ComputeAuxDataV1(nonce uint32, referrerId []byte) ([]byte, error) {
+	return ComputeAuxData(nonce, referrerId, DepositAuxV1)
+}

--- a/aux_data.go
+++ b/aux_data.go
@@ -3,13 +3,20 @@ package deposit_address
 import (
 	"crypto/sha256"
 	"encoding/binary"
+
 	"github.com/pkg/errors"
 )
 
 const (
 	DepositAuxTag     = "LombardDepositAux"
-	DepositAuxV0      = uint8(0)
 	MaxReferralIdSize = 256
+)
+
+type DepositAuxVersion uint8
+
+const (
+	DepositAuxV0 = DepositAuxVersion(0)
+	DepositAuxV1 = DepositAuxVersion(1)
 )
 
 // GetDepositAuxTagBytes Compute the aux tag bytes.
@@ -33,15 +40,18 @@ func auxDepositHasher() Sha256 {
 	return h
 }
 
-// ComputeAuxDataV0 Compute v0 AuxData given a ReferrerId
+// ComputeAuxData Compute the AuxData.
 //
 // This is defined as
 //
-//	taggedHash( Version0 || Nonce || ReferrerId )
+//	taggedHash( Version || Nonce || ReferrerId )
 //
-// where 'taggedHash' is a sha256 instance as returned by 'auxDepositHasher()',
-// 'Version0' is the byte 0x00, nonce, and 'ReferrerId' is an arbitrary 16 bytes array.
-func ComputeAuxDataV0(nonce uint32, referrerId []byte) ([]byte, error) {
+// where:
+// - 'taggedHash' is a sha256 instance as returned by 'auxDepositHasher()'
+// - 'Version' is a byte useful if different deposit versions should refer to different deposit addresses
+// - 'nonce' allows to generate different deposit addresses given same inputs
+// - 'ReferrerId' is an arbitrary 16 bytes array for application usage
+func ComputeAuxData(nonce uint32, referrerId []byte, version DepositAuxVersion) ([]byte, error) {
 	if len(referrerId) > MaxReferralIdSize {
 		return nil, errors.Errorf("wrong size for referrerId (got %v, want not greater than %v)", len(referrerId), MaxReferralIdSize)
 	}
@@ -51,10 +61,9 @@ func ComputeAuxDataV0(nonce uint32, referrerId []byte) ([]byte, error) {
 
 	h := auxDepositHasher()
 
-	// Version0
-	_, err := h.Write([]byte{DepositAuxV0})
+	_, err := h.Write([]byte{byte(version)})
 	if err != nil {
-		return nil, errors.Errorf("write version %x", []byte{DepositAuxV0})
+		return nil, errors.Errorf("write version %x", []byte{byte(version)})
 	}
 	_, err = h.Write(nonceBytes)
 	if err != nil {
@@ -66,4 +75,9 @@ func ComputeAuxDataV0(nonce uint32, referrerId []byte) ([]byte, error) {
 	}
 
 	return h.Sum(nil), nil
+}
+
+// ComputeAuxDataV0 Compute the AuxData with version 0
+func ComputeAuxDataV0(nonce uint32, referrerId []byte) ([]byte, error) {
+	return ComputeAuxData(nonce, referrerId, DepositAuxV0)
 }

--- a/aux_data.go
+++ b/aux_data.go
@@ -40,7 +40,8 @@ func auxDepositHasher() Sha256 {
 	return h
 }
 
-// computeAuxData Compute the AuxData.
+// ComputeAuxData Compute the AuxData according to the provided version. If version is not supported in
+// the ecosystem function returns an error.
 //
 // This is defined as
 //
@@ -51,9 +52,12 @@ func auxDepositHasher() Sha256 {
 // - 'Version' is a byte useful if different deposit versions should refer to different deposit addresses
 // - 'nonce' allows to generate different deposit addresses given same inputs
 // - 'ReferrerId' is an arbitrary 16 bytes array for application usage
-func computeAuxData(nonce uint32, referrerId []byte, version DepositAuxVersion) ([]byte, error) {
+func ComputeAuxData(nonce uint32, referrerId []byte, version DepositAuxVersion) ([]byte, error) {
 	if len(referrerId) > MaxReferralIdSize {
 		return nil, errors.Errorf("wrong size for referrerId (got %v, want not greater than %v)", len(referrerId), MaxReferralIdSize)
+	}
+	if version > DepositAuxV1 {
+		return nil, errors.Errorf("version is not supported")
 	}
 
 	nonceBytes := make([]byte, 4)
@@ -79,10 +83,10 @@ func computeAuxData(nonce uint32, referrerId []byte, version DepositAuxVersion) 
 
 // ComputeAuxDataV0 Compute the AuxData with version 0
 func ComputeAuxDataV0(nonce uint32, referrerId []byte) ([]byte, error) {
-	return computeAuxData(nonce, referrerId, DepositAuxV0)
+	return ComputeAuxData(nonce, referrerId, DepositAuxV0)
 }
 
 // ComputeAuxDataV1 Compute the AuxData with version 1
 func ComputeAuxDataV1(nonce uint32, referrerId []byte) ([]byte, error) {
-	return computeAuxData(nonce, referrerId, DepositAuxV1)
+	return ComputeAuxData(nonce, referrerId, DepositAuxV1)
 }

--- a/aux_data_test.go
+++ b/aux_data_test.go
@@ -2,10 +2,11 @@ package deposit_address
 
 import (
 	"encoding/hex"
-	"github.com/stretchr/testify/require"
 	"math"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestComputeAuxDataV0(t *testing.T) {
@@ -60,6 +61,63 @@ func TestComputeAuxDataV0(t *testing.T) {
 			require.NoError(t, err)
 			if !reflect.DeepEqual(hex.EncodeToString(got), tt.want) {
 				t.Errorf("ComputeAuxDataV0() = %x, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeAuxDataV1(t *testing.T) {
+	referalData, err := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
+	require.NoError(t, err)
+
+	type args struct {
+		nonce      uint32
+		referrerId []byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "successful with max uint32",
+			args: args{
+				nonce:      math.MaxUint32,
+				referrerId: referalData,
+			},
+			want: "57aedd1ef8765c190f826be6d0c54add6490bb0df5b783c151989d66c8b2b12c",
+		},
+		{
+			name: "successful with max uint32 - 1",
+			args: args{
+				nonce:      math.MaxUint32 - 1,
+				referrerId: referalData,
+			},
+			want: "46b7319fd3fd314c5f9a1fb4ed81f1f19f3ea06173827bd6ec2f8653d23bed9d",
+		},
+		{
+			name: "successful with 0",
+			args: args{
+				nonce:      0,
+				referrerId: referalData,
+			},
+			want: "7eb52f8f0d25a9fd2d7d810ded653ac10c41cbc21696ad073076b8a7d389025a",
+		},
+		{
+			name: "successful with 1",
+			args: args{
+				nonce:      1,
+				referrerId: referalData,
+			},
+			want: "a84442c7706a991e0d45027cf3926385efe3f7b95b19a8b316bdbc1c73fb79b2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ComputeAuxDataV1(tt.args.nonce, tt.args.referrerId)
+			require.NoError(t, err)
+			if !reflect.DeepEqual(hex.EncodeToString(got), tt.want) {
+				t.Errorf("ComputeAuxDataV1() = %x, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
We want to allow possibility to use the version tag in the AuxData to customize the address derivation and make deposit uniquely tied to a deposit version.

Need to merge #5 first